### PR TITLE
CPDP-1085: integrate PDF generator service

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposals/connectors/PdfGeneratorConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposals/connectors/PdfGeneratorConnector.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposals.connectors
+
+import cats.data.EitherT
+import com.google.inject.{ImplementedBy, Inject, Singleton}
+import play.mvc.Http.Status
+import uk.gov.hmrc.cgtpropertydisposals.models.Error
+import uk.gov.hmrc.cgtpropertydisposals.util.Logging
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@ImplementedBy(classOf[PdfGeneratorConnectorImpl])
+trait PdfGeneratorConnector {
+  def generatePDF(payload: Map[String, Seq[String]], headers: Seq[(String, String)])(
+    implicit hc: HeaderCarrier
+  ): EitherT[Future, Error, Stream[Char]]
+}
+
+@Singleton
+class PdfGeneratorConnectorImpl @Inject()(config: ServicesConfig, http: HttpClient)(implicit ec: ExecutionContext)
+    extends PdfGeneratorConnector
+    with Logging {
+
+  private val serviceName: String  = "pdf-generator"
+  private lazy val baseURL: String = config.baseUrl(serviceName) + config.getConfString(s"$serviceName.base-path", "")
+  private val url: String          = s"$baseURL/pdf-generator-service/generate"
+
+  override def generatePDF(payload: Map[String, Seq[String]], headers: Seq[(String, String)])(
+    implicit hc: HeaderCarrier
+  ): EitherT[Future, Error, Stream[Char]] =
+    EitherT[Future, Error, Stream[Char]](
+      http
+        .POSTForm(url, payload, headers)
+        .map[Either[Error, Stream[Char]]] { response =>
+          if (response.status != Status.OK) {
+            logger.warn(s"Could not generate PDF: http status : ${response.status} | http body : ${response.body}")
+            Left(Error("Could not generate PDF"))
+          } else {
+            Right(response.body.toStream)
+          }
+        }
+        .recover { case e => Left(Error(e)) }
+    )
+}

--- a/app/uk/gov/hmrc/cgtpropertydisposals/connectors/PdfGeneratorConnector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposals/connectors/PdfGeneratorConnector.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.cgtpropertydisposals.connectors
 import cats.data.EitherT
 import com.google.inject.{ImplementedBy, Inject, Singleton}
 import play.mvc.Http.Status
+import uk.gov.hmrc.cgtpropertydisposals.http.HttpClient._
 import uk.gov.hmrc.cgtpropertydisposals.models.Error
 import uk.gov.hmrc.cgtpropertydisposals.util.Logging
 import uk.gov.hmrc.http.HeaderCarrier
@@ -48,7 +49,7 @@ class PdfGeneratorConnectorImpl @Inject()(config: ServicesConfig, http: HttpClie
   ): EitherT[Future, Error, Stream[Char]] =
     EitherT[Future, Error, Stream[Char]](
       http
-        .POSTForm(url, payload, headers)
+        .postForm(url, payload, headers)
         .map[Either[Error, Stream[Char]]] { response =>
           if (response.status != Status.OK) {
             logger.warn(s"Could not generate PDF: http status : ${response.status} | http body : ${response.body}")

--- a/app/uk/gov/hmrc/cgtpropertydisposals/http/HttpClient.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposals/http/HttpClient.scala
@@ -47,6 +47,13 @@ object HttpClient {
     )(implicit w: Writes[A], hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
       http.POST(url, body, headers.toSeq)(w, rawHttpReads, hc, ec)
 
+    def postForm(
+      url: String,
+      body: Map[String, Seq[String]],
+      headers: Seq[(String, String)] = Seq.empty
+    )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
+      http.POSTForm(url, body, headers)(rawHttpReads, hc, ec)
+
     def put[A](
       url: String,
       body: A,

--- a/app/uk/gov/hmrc/cgtpropertydisposals/service/PdfGeneratorService.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposals/service/PdfGeneratorService.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposals.service
+
+import cats.data.EitherT
+import com.google.inject.{ImplementedBy, Inject, Singleton}
+import play.mvc.Http.{HeaderNames, MimeTypes}
+import uk.gov.hmrc.cgtpropertydisposals.connectors.PdfGeneratorConnector
+import uk.gov.hmrc.cgtpropertydisposals.models.Error
+import uk.gov.hmrc.cgtpropertydisposals.util.Logging
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+@ImplementedBy(classOf[PdfGeneratorServiceImpl])
+trait PdfGeneratorService {
+  def generatePdfBytes(html: String)(implicit hc: HeaderCarrier): EitherT[Future, Error, Stream[Char]]
+}
+
+@Singleton
+class PdfGeneratorServiceImpl @Inject()(pdfGeneratorConnector: PdfGeneratorConnector)
+    extends PdfGeneratorService
+    with Logging {
+
+  override def generatePdfBytes(html: String)(implicit hc: HeaderCarrier): EitherT[Future, Error, Stream[Char]] = {
+    val headers = Seq((HeaderNames.CONTENT_TYPE, MimeTypes.FORM))
+    val body    = Map("html" -> Seq(html), "force-pdfa" -> Seq("false"))
+    pdfGeneratorConnector.generatePDF(body, headers)
+  }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -200,6 +200,10 @@ microservice {
             port = 9995
         }
 
+        pdf-generator {
+            host = localhost
+            port = 9852
+        }
     }
 }
 

--- a/test/uk/gov/hmrc/cgtpropertydisposals/connectors/HttpSupport.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/connectors/HttpSupport.scala
@@ -58,6 +58,20 @@ trait HttpSupport { this: MockFactory with Matchers ⇒
         result.fold[Future[HttpResponse]](Future.failed(new Exception("Test exception message")))(Future.successful)
       )
 
+  def mockPostForm[A](url: String, body: Map[String, Seq[String]], headers: Map[String, String])(
+    result: Option[HttpResponse]
+  ): Unit =
+    (mockHttp
+      .POSTForm(_: String, _: Map[String, Seq[String]], _: Seq[(String, String)])(
+        _: HttpReads[HttpResponse],
+        _: HeaderCarrier,
+        _: ExecutionContext
+      ))
+      .expects(url, body, headers.toSeq, *, *, *)
+      .returning(
+        result.fold[Future[HttpResponse]](Future.failed(new Exception("Test exception message")))(Future.successful)
+      )
+
   def mockPut[A](url: String, body: A, headers: Seq[(String, String)] = Seq.empty)(result: Option[HttpResponse]): Unit =
     (mockHttp
       .PUT(_: String, _: A, _: Seq[(String, String)])(

--- a/test/uk/gov/hmrc/cgtpropertydisposals/connectors/PdfGeneratorConnectorImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/connectors/PdfGeneratorConnectorImplSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposals.connectors
+
+import com.typesafe.config.ConfigFactory
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.JsString
+import play.api.test.Helpers._
+import play.api.{Configuration, Mode}
+import uk.gov.hmrc.cgtpropertydisposals.models.Error
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.bootstrap.config.{RunMode, ServicesConfig}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class PdfGeneratorConnectorImplSpec extends WordSpec with Matchers with MockFactory with HttpSupport {
+
+  val config = Configuration(
+    ConfigFactory.parseString(
+      """
+        | microservice.services {
+        |    pdf-generator {
+        |        host = localhost
+        |        port = 9852
+        |    }
+        | }
+        |""".stripMargin
+    )
+  )
+  val connector = new PdfGeneratorConnectorImpl(new ServicesConfig(config, new RunMode(config, Mode.Test)), mockHttp)
+
+  "PdfGeneratorConnectorImpl" when {
+
+    "handling pdf generation requests" must {
+
+      implicit val hc: HeaderCarrier = HeaderCarrier()
+
+      val expectedUrl = s"http://localhost:9852/pdf-generator-service/generate"
+
+      "process unsuccessful post calls from PDF Generation Service " in {
+        List(
+          HttpResponse(400),
+          HttpResponse(500, Some(JsString("error")))
+        ).foreach { httpResponse =>
+          withClue(s"For http response [${httpResponse.toString}]") {
+            mockPostForm(expectedUrl, Map.empty, Map.empty)(Some(httpResponse))
+            await(connector.generatePDF(Map.empty, Seq.empty).value) shouldBe Left(
+              Error("Could not generate PDF")
+            )
+          }
+        }
+      }
+
+      "process successful calls from PDF generation service" in {
+        List(
+          HttpResponse(200, Some(JsString("hi")), Map.empty, Some("some pdf"))
+        ).foreach { httpResponse =>
+          withClue(s"For http response [${httpResponse.toString}]") {
+            mockPostForm(expectedUrl, Map.empty, Map.empty)(Some(httpResponse))
+            await(connector.generatePDF(Map.empty, Seq.empty).value) shouldBe Right(
+              Stream('s', 'o', 'm', 'e', ' ', 'p', 'd', 'f')
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cgtpropertydisposals/service/PdfGeneratorServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/service/PdfGeneratorServiceImplSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposals.service
+
+import akka.util.Timeout
+import cats.data.EitherT
+import com.typesafe.config.ConfigFactory
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{Matchers, WordSpec}
+import play.api.Configuration
+import play.api.test.Helpers.await
+import play.mvc.Http.{HeaderNames, MimeTypes}
+import uk.gov.hmrc.cgtpropertydisposals.connectors.PdfGeneratorConnector
+import uk.gov.hmrc.cgtpropertydisposals.models.Error
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class PdfGeneratorServiceImplSpec extends WordSpec with Matchers with MockFactory {
+  val config = Configuration(
+    ConfigFactory.parseString(
+      """
+        | microservice.services {
+        |    pdf-generator {
+        |        host = localhost
+        |        port = 9852
+        |    }
+        | }
+        |""".stripMargin
+    )
+  )
+
+  implicit val timeout: Timeout            = Timeout(5 second)
+  val mockConnector: PdfGeneratorConnector = mock[PdfGeneratorConnector]
+
+  val service = new PdfGeneratorServiceImpl(mockConnector)
+
+  def mockPdfGeneratorServiceCall(payload: Map[String, Seq[String]], headers: Seq[(String, String)])(
+    response: Either[Error, Stream[Char]]
+  ) =
+    (mockConnector
+      .generatePDF(_: Map[String, Seq[String]], _: Seq[(String, String)])(_: HeaderCarrier))
+      .expects(payload, headers, *)
+      .returning(EitherT(Future.successful(response)))
+
+  "PdfGeneratorServiceImpl" when {
+
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    "handling request to generate pdf" must {
+      "return an error" when {
+        "the http call fails" in {
+          mockPdfGeneratorServiceCall(
+            Map("html" -> Seq("<!DOCTYPE html>"), "force-pdfa" -> Seq("false")),
+            Seq((HeaderNames.CONTENT_TYPE, MimeTypes.FORM))
+          )(Left(Error("Some issue calling PDF generator service")))
+          await(service.generatePdfBytes("<!DOCTYPE html>").value).isLeft shouldBe true
+        }
+      }
+
+      "return the stream of bytes for the pdf if the call to the pdf service completed" in {
+        mockPdfGeneratorServiceCall(
+          Map("html" -> Seq("some html"), "force-pdfa" -> Seq("false")),
+          Seq((HeaderNames.CONTENT_TYPE, MimeTypes.FORM))
+        )(Right(Stream('s', 'o', 'm', 'e', 'h', 't', 'm', 'l')))
+        await(service.generatePdfBytes("some html").value) shouldBe Right(
+          Stream('s', 'o', 'm', 'e', 'h', 't', 'm', 'l')
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
With respect to testing, we can have a test-only controller method that writes the bytes from the PDF generator service to disk. The resultant file can then be opened using a PDF viewer. 

What is more important than that is to have a mechanism to view the PDF during development. The UX designers can do iterative design by running the PDF_GENERATOR_SERVICE locally using service-manager and then firing their HTML templates via POSTMAN to it. They will then receive the generated PDF which they can view and assess.