### PR TITLE
DLS-4032: [RP] Change replacement char from Underscore to Hyphen.

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposals/connectors/dms/S3Connector.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposals/connectors/dms/S3Connector.scala
@@ -85,7 +85,7 @@ class S3ConnectorImpl @Inject() (
                   .map { bytes =>
                     logger.info("Successfully downloaded files from S3")
                     Right(
-                      replaceAllInvalidCharsWithUnderScore(
+                      replaceAllInvalidCharsWithHyphen(
                         FileAttachment(
                           UUID.randomUUID().toString,
                           filename,
@@ -106,19 +106,18 @@ class S3ConnectorImpl @Inject() (
     }
   }
 
-  // It replaces all invalid characters available in Filename with underscore(_)
+  // It replaces all invalid characters available in Filename with hyphen(_)
   // to avoid issues with Windows OS
-  private def replaceAllInvalidCharsWithUnderScore(f: FileAttachment): FileAttachment = {
+  private def replaceAllInvalidCharsWithHyphen(f: FileAttachment): FileAttachment = {
     // \x00-\x1F ==> [1-32]
-    // invalidASCIIChars ++:  invalidASCIIChars2
     val invalidASCIIChars   = (0 to 31).map(_.toString).toList ++: "00,01,02,03,04,05,06,07,08,09".split(",").toList
-    val invalidSpecialChars = "[<>:/\"|?*\\\\]".r
+    val invalidSpecialChars = "[%<>:/\"|?*\\\\]".r
 
     val filenameWithExtension = f.filename.split("\\.(?=[^\\.]+$)")
 
     val updatedFilename =
-      if (invalidASCIIChars.contains(filenameWithExtension(0))) "_"
-      else invalidSpecialChars.replaceAllIn(filenameWithExtension(0), "_")
+      if (invalidASCIIChars.contains(filenameWithExtension(0))) "-"
+      else invalidSpecialChars.replaceAllIn(filenameWithExtension(0), "-")
 
     val fullUpdatedFilename =
       if (filenameWithExtension.length > 1) s"$updatedFilename.${filenameWithExtension(1)}"

--- a/test/uk/gov/hmrc/cgtpropertydisposals/connectors/dms/S3ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/connectors/dms/S3ConnectorSpec.scala
@@ -199,7 +199,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
             }
           }
 
-        "replace 31 ascii chars with underscore(_) if the file was downloaded successfully" +
+        "replace '31' ascii chars with hyphen(-) if the file was downloaded successfully" +
           "and it has a Windows OS invalid character" in {
             List(
               buildWsResponse(200)
@@ -224,14 +224,14 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
                 )
 
                 result match {
-                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "_"
+                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "-"
                   case _                                        =>
                 }
               }
             }
           }
 
-        "replace 01 ascii chars with underscore(_) if the file was downloaded successfully" +
+        "replace '01' ascii chars with hyphen(-) if the file was downloaded successfully" +
           "and it has a Windows OS invalid character" in {
             List(
               buildWsResponse(200)
@@ -256,14 +256,14 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
                 )
 
                 result match {
-                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "_"
+                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "-"
                   case _                                        =>
                 }
               }
             }
           }
 
-        "replace special chars with underscore(_) if the file was downloaded successfully" +
+        "replace special chars with hyphen(-) if the file was downloaded successfully" +
           "and it has a Windows OS invalid character" in {
             List(
               buildWsResponse(200)
@@ -288,7 +288,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
                 )
 
                 result match {
-                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample_cgt_file_name_one_.txt"
+                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample-cgt-file-name-one-.txt"
                   case _                                        =>
                 }
 
@@ -296,7 +296,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
             }
           }
 
-        "replace \" with underscore(_) if the file was downloaded successfully" +
+        "replace '\"' with hyphen(-) if the file was downloaded successfully" +
           "and it has a Windows OS invalid character" in {
             List(
               buildWsResponse(200)
@@ -321,7 +321,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
                 )
 
                 result match {
-                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample_test.txt"
+                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample-test.txt"
                   case _                                        =>
                 }
 
@@ -329,7 +329,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
             }
           }
 
-        "replace \\ with underscore(_) if the file was downloaded successfully" +
+        "replace '\\' with hyphen(-) if the file was downloaded successfully" +
           "and it has a Windows OS invalid character" in {
             List(
               buildWsResponse(200)
@@ -354,7 +354,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
                 )
 
                 result match {
-                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample_test.txt"
+                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample-test.txt"
                   case _                                        =>
                 }
 
@@ -362,7 +362,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
             }
           }
 
-        "check '%22' does not cause any issues if the file was downloaded successfully" +
+        "check '%' does not cause any issues if the file was downloaded successfully" +
           "and it has a Windows OS invalid character" in {
             List(
               buildWsResponse(200)
@@ -387,7 +387,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
                 )
 
                 result match {
-                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample%22test.txt"
+                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample-22test.txt"
                   case _                                        =>
                 }
 
@@ -395,7 +395,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
             }
           }
 
-        "replace : with underscore(_) if the file was downloaded successfully" +
+        "replace : with hyphen(-) if the file was downloaded successfully" +
           "and it has a Windows OS invalid character" in {
             List(
               buildWsResponse(200)
@@ -420,7 +420,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
                 )
 
                 result match {
-                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample_test.txt"
+                  case Right(FileAttachment(_, filename, _, _)) => filename shouldBe "sample-test.txt"
                   case _                                        =>
                 }
 
@@ -431,5 +431,7 @@ class S3ConnectorSpec extends WordSpec with Matchers with MockFactory with HttpS
       }
 
     }
+
   }
+
 }


### PR DESCRIPTION
Reverts hmrc/cgt-property-disposals#291