### PR TITLE
DLS-3705: Updated the deprecated keys

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,7 +69,7 @@ play.http.session.secure=false
 
 # The application languages
 # ~~~~~
-play.i18n.langs="en"
+play.i18n.langs=["en"]
 
 # Router
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -65,7 +65,7 @@ play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 # Session configuration
 # ~~~~~
 play.http.session.httpOnly=false
-application.session.secure=false
+play.http.session.secure=false
 
 # The application languages
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -270,3 +270,4 @@ s3 {
 }
 
 bootstrap.http.headersAllowlist=["Accept-Language"]
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,7 +69,7 @@ play.http.session.secure=false
 
 # The application languages
 # ~~~~~
-application.langs="en"
+play.i18n.langs="en"
 
 # Router
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,7 +64,7 @@ play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
 # Session configuration
 # ~~~~~
-application.session.httpOnly=false
+play.http.session.httpOnly=false
 application.session.secure=false
 
 # The application languages


### PR DESCRIPTION
The keys that have been updated in this PR are:

- application.session.httpOnly
- application.session.secure
- application.langs
