### PR TITLE
DLS-4184 | Remove hardcoded references to current tax year and peg previous year to current

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,20 @@ lazy val microservice = Project(appName, file("."))
   )
   .settings(CodeCoverageSettings.settings *)
   // Disable default sbt Test options (might change with new versions of bootstrap)
-  .settings(Test / testOptions -= Tests.Argument("-o", "-u", "target/test-reports", "-h", "target/test-reports/html-report"))
+  .settings(
+    Test / testOptions -= Tests.Argument("-o", "-u", "target/test-reports", "-h", "target/test-reports/html-report")
+  )
   // Suppress successful events in Scalatest in standard output (-o)
   // Options described here: https://www.scalatest.org/user_guide/using_scalatest_with_sbt
-  .settings(Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oNCHPQR", "-u", "target/test-reports", "-h", "target/test-reports/html-report"))
+  .settings(
+    Test / testOptions += Tests.Argument(
+      TestFrameworks.ScalaTest,
+      "-oNCHPQR",
+      "-u",
+      "target/test-reports",
+      "-h",
+      "target/test-reports/html-report"
+    )
+  )
 
 libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,11 +12,13 @@ object AppDependencies {
     "uk.gov.hmrc"                             %% s"bootstrap-backend-$playVersion"         % bootstrapPlay28Version,
     "org.typelevel"                           %% "cats-core"                               % "2.9.0",
     "org.julienrf"                            %% "play-json-derived-codecs"                % "10.1.0",
+    "com.github.pureconfig"                   %% "pureconfig"                              % "0.17.5",
     "com.googlecode.owasp-java-html-sanitizer" % "owasp-java-html-sanitizer"               % "20191001.1",
     "uk.gov.hmrc.mongo"                       %% s"hmrc-mongo-work-item-repo-$playVersion" % mongoVersion
   )
 
   def test(scope: String = "test"): Seq[ModuleID] = Seq(
+    "uk.gov.hmrc"                %% "tax-year"                      % "4.0.0"                % scope,
     "uk.gov.hmrc"                %% s"bootstrap-test-$playVersion"  % bootstrapPlay28Version % scope,
     "uk.gov.hmrc.mongo"          %% s"hmrc-mongo-test-$playVersion" % mongoVersion           % scope,
     "org.mockito"                %% "mockito-scala"                 % "1.17.12"              % scope,

--- a/test/uk/gov/hmrc/cgtpropertydisposals/models/Generators.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/models/Generators.scala
@@ -316,6 +316,8 @@ trait ReturnsGen extends LowerPriorityReturnsGen {
 
   implicit val taxYearGen: Gen[TaxYear] = gen[TaxYear]
 
+  implicit val taxYearConfigGen: Gen[TaxYearConfig] = gen[TaxYearConfig]
+
   implicit val disposalDateGen: Gen[DisposalDate] = gen[DisposalDate]
 
   implicit val calculateCgtTaxDueRequestGen: Gen[CalculateCgtTaxDueRequest] =

--- a/test/uk/gov/hmrc/cgtpropertydisposals/repositories/dms/DmsSubmissionRepoFailureSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/repositories/dms/DmsSubmissionRepoFailureSpec.scala
@@ -68,8 +68,7 @@ class DmsSubmissionRepoFailureSpec extends AnyWordSpec with Matchers with MongoS
 
     "getting" should {
       "return an error" in {
-        val dmsSubmissionRequest = sample[DmsSubmissionRequest]
-        await(repository.set(dmsSubmissionRequest).value).isLeft shouldBe true
+        await(repository.get.value).isLeft shouldBe true
       }
     }
 

--- a/test/uk/gov/hmrc/cgtpropertydisposals/service/returns/TaxYearServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/service/returns/TaxYearServiceImplSpec.scala
@@ -16,199 +16,144 @@
 
 package uk.gov.hmrc.cgtpropertydisposals.service.returns
 
-import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import com.typesafe.config.ConfigFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Configuration
-import uk.gov.hmrc.cgtpropertydisposals.models.TaxYear
-import uk.gov.hmrc.cgtpropertydisposals.models.finance.AmountInPence
+import pureconfig.generic.ProductHint
+import pureconfig.generic.auto._
+import pureconfig._
+import uk.gov.hmrc.cgtpropertydisposals.models.Generators._
+import uk.gov.hmrc.cgtpropertydisposals.models.{LatestTaxYearGoLiveDate, TaxYear, TaxYearConfig}
+import uk.gov.hmrc.time.{TaxYear => HmrcTaxYear}
 
 import java.time.LocalDate
 
-class TaxYearServiceImplSpec extends AnyWordSpec with Matchers {
-  private val taxYear2020 = TaxYear(
-    startDateInclusive = LocalDate.of(2020, 4, 6),
-    endDateExclusive = LocalDate.of(2021, 4, 6),
-    annualExemptAmountGeneral = AmountInPence.fromPounds(12300),
-    annualExemptAmountNonVulnerableTrust = AmountInPence.fromPounds(6150),
-    personalAllowance = AmountInPence.fromPounds(12500),
-    maxPersonalAllowance = AmountInPence.fromPounds(20000),
-    higherIncomePersonalAllowanceThreshold = AmountInPence.fromPounds(100000),
-    incomeTaxHigherRateThreshold = AmountInPence.fromPounds(37500),
-    cgtRateLowerBandResidential = BigDecimal(18),
-    cgtRateLowerBandNonResidential = BigDecimal(10),
-    cgtRateHigherBandResidential = BigDecimal(28),
-    cgtRateHigherBandNonResidential = BigDecimal(20),
-    maxLettingsReliefAmount = AmountInPence.fromPounds(40000)
-  )
+class TaxYearServiceImplSpec extends AnyWordSpec with Matchers with ScalaCheckPropertyChecks {
 
-  private val taxYear2021 =
-    TaxYear(
-      startDateInclusive = LocalDate.of(2021, 4, 6),
-      endDateExclusive = LocalDate.of(2022, 4, 6),
-      annualExemptAmountGeneral = AmountInPence.fromPounds(12300),
-      annualExemptAmountNonVulnerableTrust = AmountInPence.fromPounds(6150),
-      personalAllowance = AmountInPence.fromPounds(12570),
-      maxPersonalAllowance = AmountInPence.fromPounds(20000),
-      higherIncomePersonalAllowanceThreshold = AmountInPence.fromPounds(100000),
-      incomeTaxHigherRateThreshold = AmountInPence.fromPounds(37700),
-      cgtRateLowerBandResidential = BigDecimal(18),
-      cgtRateLowerBandNonResidential = BigDecimal(10),
-      cgtRateHigherBandResidential = BigDecimal(28),
-      cgtRateHigherBandNonResidential = BigDecimal(20),
-      maxLettingsReliefAmount = AmountInPence.fromPounds(40000)
+  implicit def hint[A]: ProductHint[A] = ProductHint[A](ConfigFieldMapping(CamelCase, KebabCase))
+
+  private val currentTaxYear = HmrcTaxYear.current.startYear
+  private val taxYearConfigs = (currentTaxYear to 2020 by -1).map { year =>
+    sample[TaxYearConfig].copy(startYear = year)
+  }
+
+  private def config(flag: LocalDate) = {
+
+    val taxYearsConfigObj                = ConfigWriter[List[TaxYearConfig]].to(taxYearConfigs.toList)
+    val latestTaxYearGoLiveDateConfigObj = ConfigWriter[LatestTaxYearGoLiveDate].to(
+      LatestTaxYearGoLiveDate(flag.getDayOfMonth, flag.getMonthValue, flag.getYear)
     )
 
-  private val taxYear2022 =
-    TaxYear(
-      startDateInclusive = LocalDate.of(2022, 4, 6),
-      endDateExclusive = LocalDate.of(2023, 4, 6),
-      annualExemptAmountGeneral = AmountInPence.fromPounds(12300),
-      annualExemptAmountNonVulnerableTrust = AmountInPence.fromPounds(6150),
-      personalAllowance = AmountInPence.fromPounds(12570),
-      maxPersonalAllowance = AmountInPence.fromPounds(20000),
-      higherIncomePersonalAllowanceThreshold = AmountInPence.fromPounds(100000),
-      incomeTaxHigherRateThreshold = AmountInPence.fromPounds(37700),
-      cgtRateLowerBandResidential = BigDecimal(18),
-      cgtRateLowerBandNonResidential = BigDecimal(10),
-      cgtRateHigherBandResidential = BigDecimal(28),
-      cgtRateHigherBandNonResidential = BigDecimal(20),
-      maxLettingsReliefAmount = AmountInPence.fromPounds(40000)
+    Configuration(
+      ConfigFactory.parseString(
+        s"""
+           |latest-tax-year-go-live-date = ${latestTaxYearGoLiveDateConfigObj.render()}
+           |tax-years = ${taxYearsConfigObj.render()}
+           |""".stripMargin
+      )
     )
+  }
 
-  private val taxYear2023 =
-    TaxYear(
-      startDateInclusive = LocalDate.of(2023, 4, 6),
-      endDateExclusive = LocalDate.of(2024, 4, 6),
-      annualExemptAmountGeneral = AmountInPence.fromPounds(6000),
-      annualExemptAmountNonVulnerableTrust = AmountInPence.fromPounds(6000),
-      personalAllowance = AmountInPence.fromPounds(12570),
-      maxPersonalAllowance = AmountInPence.fromPounds(20000),
-      higherIncomePersonalAllowanceThreshold = AmountInPence.fromPounds(100000),
-      incomeTaxHigherRateThreshold = AmountInPence.fromPounds(37700),
-      cgtRateLowerBandResidential = BigDecimal(18),
-      cgtRateLowerBandNonResidential = BigDecimal(10),
-      cgtRateHigherBandResidential = BigDecimal(28),
-      cgtRateHigherBandNonResidential = BigDecimal(20),
-      maxLettingsReliefAmount = AmountInPence.fromPounds(40000)
-    )
+  private val service = new TaxYearServiceImpl(config(LocalDate.now.minusMonths(1)))
 
-  private def config(flag: LocalDate) = Configuration(
-    ConfigFactory
-      .load("tax_years.conf")
-      .withValue("latest-tax-year-go-live-date.day", ConfigValueFactory.fromAnyRef(flag.getDayOfMonth))
-      .withValue("latest-tax-year-go-live-date.month", ConfigValueFactory.fromAnyRef(flag.getMonthValue))
-      .withValue("latest-tax-year-go-live-date.year", ConfigValueFactory.fromAnyRef(flag.getYear))
-  )
-
-  private val service  = new TaxYearServiceImpl(config(LocalDate.now.minusMonths(1)))
   private val service2 = new TaxYearServiceImpl(config(LocalDate.now))
+
   private val service3 = new TaxYearServiceImpl(config(LocalDate.now.plusMonths(1)))
 
   "TaxYearServiceImpl" when {
+
     "current date is after latestTaxYearGoLiveDate" when {
+
       "handling requests to get the tax year of a date" must {
-        "return a tax year 2020 if one can be found" in {
-          service.getTaxYear(taxYear2020.startDateInclusive)             shouldBe Some(taxYear2020)
-          service.getTaxYear(taxYear2020.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2020)
+
+        "return a tax year if config available for the year" in {
+          taxYearConfigs.foreach { taxYearConfig =>
+            service.getTaxYear(taxYearConfig.startDateInclusive)             shouldBe Some(taxYearConfig.as[TaxYear])
+            service.getTaxYear(taxYearConfig.endDateExclusive.minusDays(1L)) shouldBe Some(taxYearConfig.as[TaxYear])
+          }
         }
 
-        "return a tax year 2021 if one can be found" in {
-          service.getTaxYear(taxYear2021.startDateInclusive)             shouldBe Some(taxYear2021)
-          service.getTaxYear(taxYear2021.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2021)
+        "return nothing if a tax year not available in config" in {
+          service.getTaxYear(taxYearConfigs.last.startDateInclusive.minusDays(1L)) shouldBe None
+          service.getTaxYear(taxYearConfigs.head.endDateExclusive)                 shouldBe None
         }
 
-        "return a tax year 2022 if one can be found" in {
-          service.getTaxYear(taxYear2022.startDateInclusive)             shouldBe Some(taxYear2022)
-          service.getTaxYear(taxYear2022.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2022)
-        }
-
-        "return a tax year 2023 if one can be found" in {
-          service.getTaxYear(taxYear2023.startDateInclusive)             shouldBe Some(taxYear2023)
-          service.getTaxYear(taxYear2023.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2023)
-        }
-
-        "return nothing if a tax year cannot be found" in {
-          service.getTaxYear(taxYear2020.startDateInclusive.minusDays(1L)) shouldBe None
-          service.getTaxYear(taxYear2023.endDateExclusive)                 shouldBe None
-        }
       }
 
       "handling requests to get the available tax years" must {
-        "return available tax years 2020,2021,2022,2023" in {
-          service.getAvailableTaxYears shouldBe List(2023, 2022, 2021, 2020)
+
+        "return all available tax years" in {
+          service.getAvailableTaxYears shouldBe taxYearConfigs.map(_.startYear)
         }
+
       }
+
     }
 
     "current date is equal to latestTaxYearGoLiveDate" when {
       "handling requests to get the tax year of a date" must {
-        "return a tax year 2020 if one can be found" in {
-          service2.getTaxYear(taxYear2020.startDateInclusive)             shouldBe Some(taxYear2020)
-          service2.getTaxYear(taxYear2020.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2020)
+
+        "return a tax year if config available for the year" in {
+          taxYearConfigs.foreach { taxYearConfig =>
+            service2.getTaxYear(taxYearConfig.startDateInclusive)             shouldBe Some(taxYearConfig.as[TaxYear])
+            service2.getTaxYear(taxYearConfig.endDateExclusive.minusDays(1L)) shouldBe Some(taxYearConfig.as[TaxYear])
+          }
         }
 
-        "return a tax year 2021 if one can be found" in {
-          service2.getTaxYear(taxYear2021.startDateInclusive)             shouldBe Some(taxYear2021)
-          service2.getTaxYear(taxYear2021.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2021)
+        "return nothing if a tax year not available in config" in {
+          service2.getTaxYear(taxYearConfigs.last.startDateInclusive.minusDays(1L)) shouldBe None
+          service2.getTaxYear(taxYearConfigs.head.endDateExclusive)                 shouldBe None
         }
 
-        "return a tax year 2022 if one can be found" in {
-          service2.getTaxYear(taxYear2022.startDateInclusive)             shouldBe Some(taxYear2022)
-          service2.getTaxYear(taxYear2022.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2022)
-        }
-
-        "return a tax year 2023 if one can be found" in {
-          service2.getTaxYear(taxYear2023.startDateInclusive)             shouldBe Some(taxYear2023)
-          service2.getTaxYear(taxYear2023.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2023)
-        }
-
-        "return nothing if a tax year cannot be found" in {
-          service2.getTaxYear(taxYear2020.startDateInclusive.minusDays(1L)) shouldBe None
-          service2.getTaxYear(taxYear2023.endDateExclusive)                 shouldBe None
-        }
       }
 
       "handling requests to get the available tax years" must {
-        "return available tax years 2020,2021,2022,2023" in {
-          service2.getAvailableTaxYears shouldBe List(2023, 2022, 2021, 2020)
+
+        "return all available tax years" in {
+          service.getAvailableTaxYears shouldBe taxYearConfigs.map(_.startYear)
         }
+
       }
+
     }
 
     "current date is before latestTaxYearGoLiveDate" when {
+
       "handling requests to get the tax year of a date" must {
-        "return a tax year 2020 if one can be found" in {
-          service3.getTaxYear(taxYear2020.startDateInclusive)             shouldBe Some(taxYear2020)
-          service3.getTaxYear(taxYear2020.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2020)
+
+        "return a tax year if config available for the year" in {
+          taxYearConfigs.foreach { taxYearConfig =>
+            if (taxYearConfig.startYear == HmrcTaxYear.current.startYear) {
+              service3.getTaxYear(taxYearConfig.startDateInclusive)             shouldBe None
+              service3.getTaxYear(taxYearConfig.endDateExclusive.minusDays(1L)) shouldBe None
+            } else {
+              service3.getTaxYear(taxYearConfig.startDateInclusive)             shouldBe Some(taxYearConfig.as[TaxYear])
+              service3.getTaxYear(taxYearConfig.endDateExclusive.minusDays(1L)) shouldBe Some(
+                taxYearConfig.as[TaxYear]
+              )
+            }
+          }
         }
 
-        "return a tax year 2021 if one can be found" in {
-          service3.getTaxYear(taxYear2021.startDateInclusive)             shouldBe Some(taxYear2021)
-          service3.getTaxYear(taxYear2021.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2021)
+        "return nothing if a tax year not available in config" in {
+          service3.getTaxYear(taxYearConfigs.last.startDateInclusive.minusDays(1L)) shouldBe None
+          service3.getTaxYear(taxYearConfigs.head.endDateExclusive)                 shouldBe None
         }
 
-        "return a tax year 2022 if one can be found" in {
-          service3.getTaxYear(taxYear2022.startDateInclusive)             shouldBe Some(taxYear2022)
-          service3.getTaxYear(taxYear2022.endDateExclusive.minusDays(1L)) shouldBe Some(taxYear2022)
-        }
-
-        "return a tax year 2023 if one can be found" in {
-          service3.getTaxYear(taxYear2023.startDateInclusive)             shouldBe None
-          service3.getTaxYear(taxYear2023.endDateExclusive.minusDays(1L)) shouldBe None
-        }
-
-        "return nothing if a tax year cannot be found" in {
-          service3.getTaxYear(taxYear2020.startDateInclusive.minusDays(1L)) shouldBe None
-          service3.getTaxYear(taxYear2022.endDateExclusive)                 shouldBe None
-        }
       }
 
       "handling requests to get the available tax years" must {
-        "return available tax years 2020,2021,2022" in {
-          service3.getAvailableTaxYears shouldBe List(2022, 2021, 2020)
+
+        "return available previous tax years" in {
+          service3.getAvailableTaxYears shouldBe taxYearConfigs.tail.map(_.startYear)
         }
+
       }
+
     }
+
   }
+
 }


### PR DESCRIPTION
- Separate config model from the tax year model returned to FE. Not only simplifies the test fixture setup but also allows for better ways of managing ser/deser of config.
- Update tests to reflect above but also peg previous tax years (cut off being 2020) to current tax year.