### PR TITLE
DLS-10771 | Fix mongo repo unavailability tests to wait for client close

### DIFF
--- a/test/uk/gov/hmrc/cgtpropertydisposals/repositories/returns/AmendReturnsRepositoryFailureSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/repositories/returns/AmendReturnsRepositoryFailureSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.cgtpropertydisposals.repositories.returns
 
 import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
@@ -28,8 +29,9 @@ import uk.gov.hmrc.cgtpropertydisposals.repositories.DefaultCurrentInstant
 import uk.gov.hmrc.mongo.test.MongoSupport
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
-class AmendReturnsRepositoryFailureSpec extends AnyWordSpec with Matchers with MongoSupport {
+class AmendReturnsRepositoryFailureSpec extends AnyWordSpec with Matchers with MongoSupport with BeforeAndAfterAll {
   private val config = Configuration(
     ConfigFactory.parseString(
       """
@@ -45,8 +47,12 @@ class AmendReturnsRepositoryFailureSpec extends AnyWordSpec with Matchers with M
   private val submitReturnRequest = sample[SubmitReturnRequest]
   private val cgtReference        = sample[CgtReference]
 
-  "AmendReturnsRepository" when {
+  val clientClosed: Future[Unit] =
     repository.collection.countDocuments().toFuture().map(_ => mongoComponent.client.close())
+
+  override protected def beforeAll(): Unit = await(clientClosed)
+
+  "AmendReturnsRepository" when {
 
     "inserting" should {
       "insert an amend return request successfully" in {

--- a/test/uk/gov/hmrc/cgtpropertydisposals/repositories/returns/DraftReturnsRepositoryFailureSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/repositories/returns/DraftReturnsRepositoryFailureSpec.scala
@@ -33,6 +33,7 @@
 package uk.gov.hmrc.cgtpropertydisposals.repositories.returns
 
 import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
@@ -43,8 +44,9 @@ import uk.gov.hmrc.cgtpropertydisposals.models.returns.DraftReturn
 import uk.gov.hmrc.mongo.test.MongoSupport
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
-class DraftReturnsRepositoryFailureSpec extends AnyWordSpec with Matchers with MongoSupport {
+class DraftReturnsRepositoryFailureSpec extends AnyWordSpec with Matchers with MongoSupport with BeforeAndAfterAll {
   private val config = Configuration(
     ConfigFactory.parseString(
       """
@@ -58,8 +60,12 @@ class DraftReturnsRepositoryFailureSpec extends AnyWordSpec with Matchers with M
   private val draftReturn  = sample[DraftReturn]
   private val cgtReference = sample[CgtReference]
 
-  "DraftReturnsRepository" when {
+  val clientClosed: Future[Unit] =
     repository.collection.countDocuments().toFuture().map(_ => mongoComponent.client.close())
+
+  override protected def beforeAll(): Unit = await(clientClosed)
+
+  "DraftReturnsRepository" when {
 
     "inserting" should {
       "create a new draft return successfully" in {


### PR DESCRIPTION
Few more tests were failing for the same intermittent issue as `DmsSubmissionRepoFailureSpec` which was fixed in [wiremock PR](https://github.com/hmrc/cgt-property-disposals/pull/352). 
- For tests that depend on mongo repository state to be unavailable, fix to block the client close before proceeding with tests that verify it.