### PR TITLE
DLS-10832 | Reinstate poller till queue is cleared

### DIFF
--- a/app/uk/gov/hmrc/cgtpropertydisposals/config/ApplicationModule.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposals/config/ApplicationModule.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.cgtpropertydisposals.config
 
 import com.google.inject.AbstractModule
 import play.api.{Configuration, Environment}
+import uk.gov.hmrc.cgtpropertydisposals.service.dms.DmsSubmissionPoller
 
 import java.time.Clock
 
@@ -28,6 +29,7 @@ class ApplicationModule(environment: Environment, config: Configuration) extends
     } else {
       bind(classOf[InternalAuthTokenInitialiser]).to(classOf[NoOpInternalAuthTokenInitialiser]).asEagerSingleton()
     }
+    bind(classOf[DmsSubmissionPoller]).asEagerSingleton()
     bind(classOf[Clock]).toInstance(Clock.systemDefaultZone())
   }
 }

--- a/app/uk/gov/hmrc/cgtpropertydisposals/repositories/dms/DmsSubmissionRepo.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposals/repositories/dms/DmsSubmissionRepo.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposals.repositories.dms
+
+import cats.data.EitherT
+import com.google.inject.ImplementedBy
+import org.bson.types.ObjectId
+import play.api.Configuration
+import uk.gov.hmrc.cgtpropertydisposals.models.Error
+import uk.gov.hmrc.cgtpropertydisposals.service.dms.DmsSubmissionRequest
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.workitem.ProcessingStatus.ToDo
+import uk.gov.hmrc.mongo.workitem._
+import uk.gov.hmrc.play.http.logging.Mdc.preservingMdc
+
+import java.time.{Duration, Instant}
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@ImplementedBy(classOf[DefaultDmsSubmissionRepo])
+trait DmsSubmissionRepo {
+  def set(dmsSubmissionRequest: DmsSubmissionRequest): EitherT[Future, Error, WorkItem[DmsSubmissionRequest]]
+
+  def get: EitherT[Future, Error, Option[WorkItem[DmsSubmissionRequest]]]
+
+  def setProcessingStatus(
+    id: ObjectId,
+    status: ProcessingStatus
+  ): EitherT[Future, Error, Boolean]
+
+  def setResultStatus(id: ObjectId, status: ResultStatus): EitherT[Future, Error, Boolean]
+}
+
+@Singleton
+class DefaultDmsSubmissionRepo @Inject() (
+  mongo: MongoComponent,
+  configuration: Configuration
+)(implicit ec: ExecutionContext)
+    extends WorkItemRepository[DmsSubmissionRequest](
+      collectionName = "dms-submission-request-work-item",
+      mongoComponent = mongo,
+      itemFormat = DmsSubmissionRequest.dmsSubmissionRequestFormat,
+      workItemFields = WorkItemFields.default
+    )
+    with DmsSubmissionRepo {
+
+  override def now(): Instant =
+    Instant.now()
+
+  override def inProgressRetryAfter: Duration = Duration.ofMillis(configuration.getMillis(inProgressRetryAfterProperty))
+
+  private def inProgressRetryAfterProperty = "dms.submission-poller.in-progress-retry-after"
+
+  private val retryPeriod = inProgressRetryAfter.getSeconds
+
+  override def set(dmsSubmissionRequest: DmsSubmissionRequest): EitherT[Future, Error, WorkItem[DmsSubmissionRequest]] =
+    EitherT[Future, Error, WorkItem[DmsSubmissionRequest]](
+      preservingMdc {
+        pushNew(dmsSubmissionRequest, now(), (_: DmsSubmissionRequest) => ToDo).map(item => Right(item)).recover {
+          case exception: Exception => Left(Error(exception))
+        }
+      }
+    )
+
+  override def get: EitherT[Future, Error, Option[WorkItem[DmsSubmissionRequest]]] =
+    EitherT[Future, Error, Option[WorkItem[DmsSubmissionRequest]]](
+      preservingMdc {
+        super
+          .pullOutstanding(failedBefore = now().minusMillis(retryPeriod), availableBefore = now())
+          .map(workItem => Right(workItem))
+          .recover { case exception: Exception =>
+            Left(Error(exception))
+          }
+      }
+    )
+
+  override def setProcessingStatus(
+    id: ObjectId,
+    status: ProcessingStatus
+  ): EitherT[Future, Error, Boolean] =
+    EitherT[Future, Error, Boolean](
+      preservingMdc {
+        markAs(id, status, Some(now().plusMillis(retryPeriod)))
+          .map(result => Right(result))
+          .recover { case exception: Exception =>
+            Left(Error(exception))
+          }
+      }
+    )
+
+  override def setResultStatus(id: ObjectId, status: ResultStatus): EitherT[Future, Error, Boolean] =
+    EitherT[Future, Error, Boolean](
+      preservingMdc {
+        complete(id, status).map(result => Right(result)).recover { case exception: Exception =>
+          Left(Error(exception))
+        }
+      }
+    )
+}

--- a/app/uk/gov/hmrc/cgtpropertydisposals/service/dms/DmsSubmissionPoller.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposals/service/dms/DmsSubmissionPoller.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposals.service.dms
+
+import cats.data.EitherT
+import cats.instances.future._
+import com.google.inject.{ImplementedBy, Inject, Singleton}
+import org.apache.pekko.actor.ActorSystem
+import uk.gov.hmrc.cgtpropertydisposals.models.{Error, UUIDGenerator}
+import uk.gov.hmrc.cgtpropertydisposals.service.dms.DmsSubmissionPoller.OnCompleteHandler
+import uk.gov.hmrc.cgtpropertydisposals.util.{FileIOExecutionContext, Logging}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.mongo.workitem.ProcessingStatus.{Failed, PermanentlyFailed, Succeeded}
+import uk.gov.hmrc.mongo.workitem.WorkItem
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Random
+
+@Singleton
+class DmsSubmissionPoller @Inject() (
+  actorSystem: ActorSystem,
+  dmsSubmissionService: DmsSubmissionService,
+  dmsSubmissionPollerContext: FileIOExecutionContext,
+  servicesConfig: ServicesConfig,
+  onCompleteHandler: OnCompleteHandler,
+  uuidGenerator: UUIDGenerator
+)(implicit
+  executionContext: FileIOExecutionContext
+) extends Logging {
+
+  private val jitteredInitialDelay: FiniteDuration = FiniteDuration(
+    servicesConfig.getDuration("dms.submission-poller.initial-delay").toMillis,
+    TimeUnit.MILLISECONDS
+  ) + FiniteDuration(
+    Random.nextInt(servicesConfig.getDuration("dms.submission-poller.jitter-period").toMillis.toInt + 1).toLong,
+    TimeUnit.MILLISECONDS
+  )
+
+  private val formIdConst = "CGTSUBMITDOC"
+
+  private val pollerInterval: FiniteDuration =
+    FiniteDuration(servicesConfig.getDuration("dms.submission-poller.interval").toMillis, TimeUnit.MILLISECONDS)
+
+  private val failureCountLimit: Int = servicesConfig.getInt("dms.submission-poller.failure-count-limit")
+
+  actorSystem.scheduler.scheduleWithFixedDelay(jitteredInitialDelay, pollerInterval)(() => poller())(
+    dmsSubmissionPollerContext
+  )
+
+  private def getLogMessage(workItem: WorkItem[DmsSubmissionRequest], stateIndicator: String) =
+    s"DMS Submission poller: $stateIndicator:  work-item-id: ${workItem.id}, work-item-failure-count: ${workItem.failureCount}, " +
+      s"work-item-status: ${workItem.status}, work-item-updatedAt : ${workItem.updatedAt}, " +
+      s"work-item-cgt-reference: ${workItem.item.cgtReference}, " +
+      s"work-item-form-bundle-id: ${workItem.item.formBundleId}"
+
+  private def poller(): Unit = {
+    val result: EitherT[Future, Error, Unit] = dmsSubmissionService.dequeue.semiflatMap {
+      case Some(workItem) =>
+        if (workItem.failureCount == failureCountLimit) {
+          logger.warn(getLogMessage(workItem, "work-item permanently failed"))
+          val _ = dmsSubmissionService.setResultStatus(workItem.id, PermanentlyFailed)
+          Future.successful(())
+        } else {
+          val id = uuidGenerator.nextId()
+          logger.info(getLogMessage(workItem, s"processing work-item with id $id"))
+
+          dmsSubmissionService
+            .submitToDms(
+              workItem.item.html,
+              formIdConst,
+              workItem.item.cgtReference,
+              workItem.item.completeReturn
+            )(new HeaderCarrier())
+            .fold(
+              { error =>
+                logger.warn(getLogMessage(workItem, s"work-item failed with error: $error"))
+                val _ = dmsSubmissionService.setProcessingStatus(workItem.id, Failed)
+              },
+              { envelopeId =>
+                logger.info(getLogMessage(workItem, s"work-item succeeded: envelope id : $envelopeId"))
+                val _ = dmsSubmissionService.setResultStatus(workItem.id, Succeeded)
+              }
+            )
+        }
+
+      case None =>
+        logger.info("DMS Submission poller: no work items")
+        Future.successful(())
+    }
+
+    result.value.onComplete(_ => onCompleteHandler.onComplete())
+  }
+}
+
+object DmsSubmissionPoller {
+  @ImplementedBy(classOf[DefaultOnCompleteHandler])
+  trait OnCompleteHandler {
+    def onComplete(): Unit
+  }
+
+  @Singleton
+  class DefaultOnCompleteHandler extends OnCompleteHandler {
+    override def onComplete(): Unit = ()
+  }
+}

--- a/app/uk/gov/hmrc/cgtpropertydisposals/service/dms/DmsSubmissionService.scala
+++ b/app/uk/gov/hmrc/cgtpropertydisposals/service/dms/DmsSubmissionService.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.cgtpropertydisposals.service.dms
 import cats.data.EitherT
 import cats.implicits.toTraverseOps
 import com.google.inject.{ImplementedBy, Inject, Singleton}
+import org.bson.types.ObjectId
 import play.api.{ConfigLoader, Configuration}
 import uk.gov.hmrc.cgtpropertydisposals.connectors.dms.DmsConnector
 import uk.gov.hmrc.cgtpropertydisposals.models.Error
@@ -26,9 +27,11 @@ import uk.gov.hmrc.cgtpropertydisposals.models.dms._
 import uk.gov.hmrc.cgtpropertydisposals.models.ids.CgtReference
 import uk.gov.hmrc.cgtpropertydisposals.models.returns.CompleteReturn
 import uk.gov.hmrc.cgtpropertydisposals.models.upscan.UpscanCallBack.UpscanSuccess
+import uk.gov.hmrc.cgtpropertydisposals.repositories.dms.DmsSubmissionRepo
 import uk.gov.hmrc.cgtpropertydisposals.service.upscan.UpscanService
 import uk.gov.hmrc.cgtpropertydisposals.util.{FileIOExecutionContext, Logging}
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.mongo.workitem.{ProcessingStatus, ResultStatus, WorkItem}
 
 import java.util.Base64
 import scala.concurrent.Future
@@ -41,12 +44,20 @@ trait DmsSubmissionService {
     cgtReference: CgtReference,
     completeReturn: CompleteReturn
   )(implicit hc: HeaderCarrier): EitherT[Future, Error, DmsEnvelopeId]
+
+  def dequeue: EitherT[Future, Error, Option[WorkItem[DmsSubmissionRequest]]]
+
+  def setProcessingStatus(id: ObjectId, status: ProcessingStatus): EitherT[Future, Error, Boolean]
+
+  def setResultStatus(id: ObjectId, status: ResultStatus): EitherT[Future, Error, Boolean]
+
 }
 
 @Singleton
 class DefaultDmsSubmissionService @Inject() (
   dmsConnector: DmsConnector,
   upscanService: UpscanService,
+  dmsSubmissionRepo: DmsSubmissionRepo,
   configuration: Configuration
 )(implicit ec: FileIOExecutionContext)
     extends DmsSubmissionService
@@ -104,4 +115,13 @@ class DefaultDmsSubmissionService @Inject() (
 
     mandatoryEvidence.toList.map(_.upscanSuccess) ::: supportingEvidences
   }
+
+  override def dequeue: EitherT[Future, Error, Option[WorkItem[DmsSubmissionRequest]]] =
+    dmsSubmissionRepo.get
+
+  override def setProcessingStatus(id: ObjectId, status: ProcessingStatus): EitherT[Future, Error, Boolean] =
+    dmsSubmissionRepo.setProcessingStatus(id, status)
+
+  override def setResultStatus(id: ObjectId, status: ResultStatus): EitherT[Future, Error, Boolean] =
+    dmsSubmissionRepo.setResultStatus(id, status)
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -182,6 +182,17 @@ retry {
 dms {
   queue-name = "queue-name"
   b64-business-area = "YnVzaW5lc3MtYXJlYQ=="
+  submission-poller {
+    jitter-period = 5 seconds
+    initial-delay = 10 minutes
+    interval = 120 seconds
+    failure-count-limit = 50
+    in-progress-retry-after = 5000 # milliseconds as required by work-item-repo library
+    mongo {
+      ttl = 7 days
+    }
+  }
+  backscan.enabled = true
 }
 
 file-io-dispatcher {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
   private val mongoVersion = "2.6.0"
   private val pekkoVersion = "1.1.3"
 
-  private val bootstrapVersion = "9.11.0"
+  private val bootstrapVersion = "9.12.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                             %% s"bootstrap-backend-$playVersion"         % bootstrapVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc"       %% "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       %% "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework" %% "sbt-plugin"            % "3.0.6")
+addSbtPlugin("org.playframework" %% "sbt-plugin"            % "3.0.7")
 addSbtPlugin("org.scalameta"     %% "sbt-scalafmt"          % "2.5.2")
 addSbtPlugin("org.scoverage"     %% "sbt-scoverage"         % "2.3.0")
 

--- a/test/uk/gov/hmrc/cgtpropertydisposals/repositories/dms/DmsSubmissionRepoFailureSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/repositories/dms/DmsSubmissionRepoFailureSpec.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposals.repositories.dms
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.Configuration
+import play.api.test.Helpers._
+import uk.gov.hmrc.cgtpropertydisposals.models.Generators.{sample, _}
+import uk.gov.hmrc.cgtpropertydisposals.service.dms.DmsSubmissionRequest
+import uk.gov.hmrc.mongo.test.MongoSupport
+import uk.gov.hmrc.mongo.workitem.ProcessingStatus.{Failed, PermanentlyFailed, Succeeded}
+import uk.gov.hmrc.mongo.workitem.WorkItem
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class DmsSubmissionRepoFailureSpec
+    extends AnyWordSpec
+    with Matchers
+    with MongoSupport
+    with BeforeAndAfterAll
+    with Eventually {
+
+  private val config = Configuration(
+    ConfigFactory.parseString(
+      """
+        |dms {
+        |    queue-name = "queue-name"
+        |    b64-business-area = "YnVzaW5lc3MtYXJlYQ=="
+        |    submission-poller {
+        |        initial-delay = 10 seconds
+        |        interval = 1 seconds
+        |        failure-count-limit = 10
+        |        in-progress-retry-after = 1000
+        |        mongo {
+        |            ttl = 604800 seconds # 7 days
+        |        }
+        |    }
+        |}
+        |""".stripMargin
+    )
+  )
+
+  val repository = new DefaultDmsSubmissionRepo(
+    mongoComponent,
+    config
+  )
+
+  val clientClosed: Future[Unit] = repository.count(Succeeded).map(_ => mongoComponent.client.close())
+
+  override protected def beforeAll(): Unit = await(clientClosed)
+
+  "A broken DmsSubmission Repo" when {
+    "inserting" should {
+      "return an error" in {
+        val dmsSubmissionRequest = sample[DmsSubmissionRequest]
+        await(repository.set(dmsSubmissionRequest).value).isLeft shouldBe true
+      }
+    }
+
+    "getting" should {
+      "return an error" in {
+        await(repository.get.value).isLeft shouldBe true
+      }
+    }
+
+    "set processing status" should {
+      "return an error" in {
+        val workItem = sample[WorkItem[DmsSubmissionRequest]]
+        await(repository.setProcessingStatus(workItem.id, Failed).value).isLeft shouldBe true
+      }
+    }
+
+    "set result status" should {
+      "update the work item status" in {
+        val workItem = sample[WorkItem[DmsSubmissionRequest]]
+        await(repository.setResultStatus(workItem.id, PermanentlyFailed).value).isLeft shouldBe true
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cgtpropertydisposals/repositories/dms/DmsSubmissionRepoSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/repositories/dms/DmsSubmissionRepoSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposals.repositories.dms
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.Configuration
+import play.api.test.Helpers._
+import uk.gov.hmrc.cgtpropertydisposals.models
+import uk.gov.hmrc.cgtpropertydisposals.models.Generators.{sample, _}
+import uk.gov.hmrc.cgtpropertydisposals.service.dms.DmsSubmissionRequest
+import uk.gov.hmrc.mongo.test.CleanMongoCollectionSupport
+import uk.gov.hmrc.mongo.workitem.ProcessingStatus.{Failed, InProgress, PermanentlyFailed}
+import uk.gov.hmrc.mongo.workitem.WorkItem
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class DmsSubmissionRepoSpec extends AnyWordSpec with Matchers with CleanMongoCollectionSupport {
+  private val config = Configuration(
+    ConfigFactory.parseString(
+      """
+        |dms {
+        |    queue-name = "queue-name"
+        |    b64-business-area = "YnVzaW5lc3MtYXJlYQ=="
+        |    submission-poller {
+        |        initial-delay = 10 seconds
+        |        interval = 1 seconds
+        |        failure-count-limit = 10
+        |        in-progress-retry-after = 1000
+        |        mongo {
+        |            ttl = 604800 seconds # 7 days
+        |        }
+        |    }
+        |}
+        |""".stripMargin
+    )
+  )
+
+  val repository = new DefaultDmsSubmissionRepo(
+    mongoComponent,
+    config
+  )
+
+  "DmsSubmission Repo" when {
+    "get" should {
+      "return some work item if one exists" in {
+        val dmsSubmissionRequest = sample[DmsSubmissionRequest]
+        await(repository.set(dmsSubmissionRequest).value).map(item => item.item) shouldBe Right(dmsSubmissionRequest)
+
+        await(repository.get.value).map(maybeWorkItem => maybeWorkItem.map(workItem => workItem.item)) shouldBe Right(
+          Some(dmsSubmissionRequest)
+        )
+      }
+
+      "return none if no work item exists " in {
+        await(
+          repository.get.value
+        ).map(mw => mw.map(s => s.item)) shouldBe Right(None)
+      }
+    }
+
+    "set processing status" should {
+      "update the work item status" in {
+        val dmsSubmissionRequest                                           = sample[DmsSubmissionRequest]
+        val workItem: Either[models.Error, WorkItem[DmsSubmissionRequest]] =
+          await(repository.set(dmsSubmissionRequest).value)
+        workItem.map(wi => await(repository.setProcessingStatus(wi.id, Failed).value) shouldBe Right(true))
+      }
+    }
+
+    "set result status" should {
+      "update the work item status" in {
+        val dmsSubmissionRequest                                           = sample[DmsSubmissionRequest]
+        val workItem: Either[models.Error, WorkItem[DmsSubmissionRequest]] =
+          await(repository.set(dmsSubmissionRequest).value)
+        val _                                                              =
+          workItem.map(wi => await(repository.setProcessingStatus(wi.id, InProgress).value))
+        workItem.map(wi => await(repository.setResultStatus(wi.id, PermanentlyFailed).value) shouldBe Right(true))
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cgtpropertydisposals/service/dms/DmsSubmissionPollerSpec.scala
+++ b/test/uk/gov/hmrc/cgtpropertydisposals/service/dms/DmsSubmissionPollerSpec.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cgtpropertydisposals.service.dms
+
+import cats.data.EitherT
+import cats.instances.future._
+import com.typesafe.config.ConfigFactory
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.testkit.{TestKit, TestProbe}
+import org.bson.types.ObjectId
+import org.mockito.IdiomaticMockito
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.Configuration
+import uk.gov.hmrc.cgtpropertydisposals.models.Generators._
+import uk.gov.hmrc.cgtpropertydisposals.models.dms.{B64Html, DmsEnvelopeId}
+import uk.gov.hmrc.cgtpropertydisposals.models.ids.CgtReference
+import uk.gov.hmrc.cgtpropertydisposals.models.returns.CompleteReturn
+import uk.gov.hmrc.cgtpropertydisposals.models.{Error, UUIDGenerator}
+import uk.gov.hmrc.cgtpropertydisposals.service.dms.DmsSubmissionPoller.OnCompleteHandler
+import uk.gov.hmrc.cgtpropertydisposals.util.FileIOExecutionContext
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.mongo.workitem.ProcessingStatus.{Failed, PermanentlyFailed, Succeeded, ToDo}
+import uk.gov.hmrc.mongo.workitem.{ProcessingStatus, ResultStatus, WorkItem}
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+
+class DmsSubmissionPollerSpec
+    extends TestKit(ActorSystem.create("dms-submission-poller"))
+    with AnyWordSpecLike
+    with Matchers
+    with IdiomaticMockito
+    with Eventually
+    with BeforeAndAfterAll {
+
+  object TestOnCompleteHandler {
+    case object Completed
+  }
+
+  class TestOnCompleteHandler(reportTo: ActorRef) extends OnCompleteHandler {
+    override def onComplete(): Unit = reportTo ! TestOnCompleteHandler.Completed
+  }
+
+  override def afterAll(): Unit =
+    TestKit.shutdownActorSystem(system)
+
+  implicit val executionContext: ExecutionContextExecutor = ExecutionContext.global
+
+  private val mockUUIDGenerator = mock[UUIDGenerator]
+  val formIdConst               = "CGTSUBMITDOC"
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  private val config = Configuration(
+    ConfigFactory.parseString(
+      """
+        |dms {
+        |    queue-name = "queue-name"
+        |    b64-business-area = "YnVzaW5lc3MtYXJlYQ=="
+        |    submission-poller {
+        |        jitter-period = 1 millisecond
+        |        initial-delay = 1 millisecond
+        |        interval = 120 seconds
+        |        failure-count-limit = 10
+        |        in-progress-retry-after = 5000 # milliseconds as required by work-item-repo library
+        |        mongo {
+        |            ttl = 7 days
+        |        }
+        |    }
+        |}
+        |
+        |""".stripMargin
+    )
+  )
+
+  private val mockDmsSubmissionService                                     = mock[DmsSubmissionService]
+  implicit val dmsSubmissionPollerExecutionContext: FileIOExecutionContext = new FileIOExecutionContext(system)
+  val servicesConfig                                                       = new ServicesConfig(config)
+
+  private def mockDmsSubmissionRequestDequeue()(response: Either[Error, Option[WorkItem[DmsSubmissionRequest]]]) =
+    mockDmsSubmissionService.dequeue.returns(EitherT.fromEither[Future](response))
+
+  private def mockSubmitToDms(
+    html: B64Html,
+    formBundleId: String,
+    cgtReference: CgtReference,
+    completeReturn: CompleteReturn
+  )(response: Either[Error, DmsEnvelopeId]) =
+    mockDmsSubmissionService
+      .submitToDms(html, formBundleId, cgtReference, completeReturn)
+      .returns(EitherT.fromEither(response))
+
+  private def mockSetProcessingStatus(id: ObjectId, status: ProcessingStatus)(response: Either[Error, Boolean]) =
+    mockDmsSubmissionService
+      .setProcessingStatus(id, status)
+      .returns(EitherT.fromEither[Future](response))
+
+  private def mockSetResultStatus(id: ObjectId, status: ResultStatus)(response: Either[Error, Boolean]) =
+    mockDmsSubmissionService
+      .setResultStatus(id, status)
+      .returns(EitherT.fromEither[Future](response))
+
+  private def mockNextUUID(uuid: UUID) =
+    mockUUIDGenerator.nextId().returns(uuid)
+
+  "DMS Submission Poller" when {
+    "it picks up a work item" must {
+      "process the work item and set it to succeed if the dms submission is successful" in {
+        val onCompleteListener = TestProbe()
+        val workItem           = sample[WorkItem[DmsSubmissionRequest]].copy(failureCount = 0, status = ToDo)
+        val id                 = UUID.randomUUID()
+
+        mockDmsSubmissionRequestDequeue()(Right(Some(workItem)))
+        mockNextUUID(id)
+        mockSubmitToDms(
+          workItem.item.html,
+          formIdConst,
+          workItem.item.cgtReference,
+          workItem.item.completeReturn
+        )(Right(DmsEnvelopeId("id")))
+        mockSetResultStatus(workItem.id, Succeeded)(Right(true))
+
+        val _ =
+          new DmsSubmissionPoller(
+            system,
+            mockDmsSubmissionService,
+            dmsSubmissionPollerExecutionContext,
+            servicesConfig,
+            new TestOnCompleteHandler(onCompleteListener.ref),
+            mockUUIDGenerator
+          )
+
+        onCompleteListener.expectMsg(TestOnCompleteHandler.Completed)
+      }
+    }
+
+    "process the work item and set it to fail if the dms submission is not successful" in {
+      val onCompleteListener = TestProbe()
+
+      val workItem = sample[WorkItem[DmsSubmissionRequest]].copy(failureCount = 0, status = ToDo)
+      val id       = UUID.randomUUID()
+
+      mockDmsSubmissionRequestDequeue()(Right(Some(workItem)))
+      mockNextUUID(id)
+      mockSubmitToDms(
+        workItem.item.html,
+        formIdConst,
+        workItem.item.cgtReference,
+        workItem.item.completeReturn
+      )(Left(Error("some-error")))
+      mockSetProcessingStatus(workItem.id, Failed)(Right(true))
+
+      val _ =
+        new DmsSubmissionPoller(
+          system,
+          mockDmsSubmissionService,
+          dmsSubmissionPollerExecutionContext,
+          servicesConfig,
+          new TestOnCompleteHandler(onCompleteListener.ref),
+          mockUUIDGenerator
+        )
+
+      onCompleteListener.expectMsg(TestOnCompleteHandler.Completed)
+    }
+
+    "process the work item and set it to permanently failed if failure count has been reached" in {
+      val onCompleteListener = TestProbe()
+
+      val workItem = sample[WorkItem[DmsSubmissionRequest]].copy(failureCount = 10, status = Failed)
+      mockDmsSubmissionRequestDequeue()(Right(Some(workItem)))
+      mockSetResultStatus(workItem.id, PermanentlyFailed)(Right(true))
+
+      val _ =
+        new DmsSubmissionPoller(
+          system,
+          mockDmsSubmissionService,
+          dmsSubmissionPollerExecutionContext,
+          servicesConfig,
+          new TestOnCompleteHandler(onCompleteListener.ref),
+          mockUUIDGenerator
+        )
+
+      onCompleteListener.expectMsg(TestOnCompleteHandler.Completed)
+    }
+
+    "it polls and there are no work items" must {
+      "do nothing" in {
+        val onCompleteListener = TestProbe()
+
+        mockDmsSubmissionRequestDequeue()(Right(None))
+        val _ =
+          new DmsSubmissionPoller(
+            system,
+            mockDmsSubmissionService,
+            dmsSubmissionPollerExecutionContext,
+            servicesConfig,
+            new TestOnCompleteHandler(onCompleteListener.ref),
+            mockUUIDGenerator
+          )
+
+        onCompleteListener.expectMsg(TestOnCompleteHandler.Completed)
+      }
+    }
+  }
+}


### PR DESCRIPTION
A temporary measure to reinstate poller as part of DMS migration. This is to avoid having to shutter the service and wait for current queue to clear. Risk with that is, we might have to shutter for long considering the performance of s3 file processing. Ignore this and releasing will lead to data loss.
So, ideal thing to do in this case is to have poller running in background to process any pending work items and publish to DMS. No new work items will enqueued. Thanks